### PR TITLE
Allow checking of files before upload, remove drops where not needed

### DIFF
--- a/drops.js
+++ b/drops.js
@@ -26,6 +26,19 @@
         });
     };
 
+    window.drops_remove = function(selector) {
+        var el = document.querySelector(selector);
+        var removeHandler = function (name) {
+            var oldHandler = document[name];
+            if(oldHandler) {
+                el.removeEventListener(name, oldHandler, false);
+            }
+        }
+
+        Array('dragenter', 'dragover', 'dragexit', 'dragleave', 'dragend', 'drop')
+            .forEach(removeHandler);
+    };
+
     o.support = function() {
         var xhr = new XMLHttpRequest();
         var xhr2 = !!(xhr && ("upload" in xhr) && ("onprogress" in xhr.upload));

--- a/drops.js
+++ b/drops.js
@@ -14,10 +14,10 @@
         o.when(el, "dragleave", options.dragleave);
         o.when(el, "dragend",   options.dragend);
 
-        o.when(el, "drop", options.dropped || drops_runner);
+        o.when(el, "drop", options.dropped || drops.runner);
     };
 
-    window.drops_runner = function(event, options) {
+    window.drops.runner = function(event, options) {
         o.options.url = options ? options.url : o.options.url;
 
         if(o.options.drop) o.options.drop(event);
@@ -26,17 +26,22 @@
         });
     };
 
-    window.drops_remove = function(selector) {
+    window.drops.remove = function(selector) {
         var el = document.querySelector(selector);
-        var removeHandler = function (name) {
-            var oldHandler = document[name];
-            if(oldHandler) {
-                el.removeEventListener(name, oldHandler, false);
+        var events = [
+            'dragenter',
+            'dragover',
+            'dragexit',
+            'dragleave',
+            'dragend',
+            'drop'
+        ];
+
+        for (var i = 0; i < events.length; ++i) {
+            if (document[events[i]]) {
+                el.removeEventListener(events[i], document[events[i]], false);
             }
         }
-
-        Array('dragenter', 'dragover', 'dragexit', 'dragleave', 'dragend', 'drop')
-            .forEach(removeHandler);
     };
 
     o.support = function() {

--- a/drops.js
+++ b/drops.js
@@ -7,17 +7,22 @@
         if(!o.support()) return;
         var el = document.querySelector(selector);
 
+        o.options = options;
         o.when(el, "dragenter", options.dragenter);
         o.when(el, "dragover",  options.dragover);
         o.when(el, "dragexit",  options.dragexit);
         o.when(el, "dragleave", options.dragleave);
         o.when(el, "dragend",   options.dragend);
 
-        o.when(el, "drop", function(event) {
-            if(options.drop) options.drop(event);
-            o.readFiles(event.dataTransfer.files, options, function(files) {
-                o.uploadFiles(files, options, options.complete);
-            });
+        o.when(el, "drop", options.dropped || drops_runner);
+    };
+
+    window.drops_runner = function(event, options) {
+        o.options.url = options ? options.url : o.options.url;
+
+        if(o.options.drop) o.options.drop(event);
+        o.readFiles(event.dataTransfer.files, o.options, function(files) {
+            o.uploadFiles(files, o.options, o.options.complete);
         });
     };
 


### PR DESCRIPTION
I've added two features:

-  `dropped` is split into `dropped` and `drops_runner`, to allow running code before the actual upload is performed, typically to check file sizes and -types. `drops` run without a custom `dropped`-function will behave exactly as before.

- Added `drops_remove` to remove file-drop-handlers where they aren't wanted.